### PR TITLE
#1 - added ubuntu 12.04 platform entry for libreadline package

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,6 +31,9 @@ packages = value_for_platform(
   ["centos", "redhat", "fedora"] => {
     'default' => ['readline-devel', 'openssl-devel', 'patch']
   },
+  ["ubuntu"] => {
+    '12.04' => ['libreadline-dev', 'libssl-dev']
+  },
   "default" => ['libreadline5-dev', 'libssl-dev']
 )
 


### PR DESCRIPTION
Fix for https://github.com/miketheman/ruby_enterprise/issues/1
Tested on Ubuntu 12.04 and Ubuntu 10.04
